### PR TITLE
Add Envoy stats port to patch

### DIFF
--- a/patch/patch.go
+++ b/patch/patch.go
@@ -50,13 +50,13 @@ const (
 		{
 		  "runAsUser": 1337
 		},
-        "ports": [
-          {
-            "containerPort": 9901,
-            "name": "stats",
-            "protocol": "TCP"
-          }
-        ],
+	      "ports": [
+		{
+		  "containerPort": 9901,
+		  "name": "stats",
+		  "protocol": "TCP"
+		}
+	      ],
 	      "env": [
 		{
 		  "name": "APPMESH_VIRTUAL_NODE_NAME",


### PR DESCRIPTION
Allow Prometheus to automatically discover the Envoy scraping endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
