### PR TITLE
Make AppMesh region optional by reading from ec2 metadata service

### DIFF
--- a/demo/ns.yaml
+++ b/demo/ns.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: appmesh-demo
+  labels:
+    appmesh.k8s.aws/sidecarInjectorWebhook : enabled

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/awslabs/aws-app-mesh-inject
 
 require (
+	github.com/aws/aws-sdk-go v1.18.4 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/aws/aws-sdk-go v1.18.4 h1:zqlGJ5hF7CqFkQe5nprfaxo50QXsB1hf74QpQKPYtGY=
+github.com/aws/aws-sdk-go v1.18.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/davecgh/go-spew v0.0.0-20170626231645-782f4967f2dc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -14,6 +16,7 @@ github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhp
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be h1:AHimNtVIpiBjPUhEF5KNCkrUyqTSA5zWUl8sQ2bfGBE=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -64,7 +64,7 @@ spec:
           image: 072792469044.dkr.ecr.eu-west-1.amazonaws.com/aws-app-mesh-inject:${TAG}
           env:
             - name: APPMESH_REGION
-              value: ${REGION}
+              value: ${APPMESH_REGION}
             - name: APPMESH_NAME
               value: ${MESH}
             - name: APPMESH_LOG_LEVEL


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-app-mesh-inject/issues/13

*Description of changes:*
This change makes AppMesh region optional by reading from ec2 metadata service. To override, user can specify an non-empty env variable `APPMESH_REGION`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
