### PR TITLE
Removed the namespace from the default virtual node naming convention

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -193,7 +193,7 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 		// if virtual router name isn't specified in the pod annotation, use the controller owner name instead.
 		// https://github.com/awslabs/aws-app-mesh-inject/issues/4
 		if controllerName := s.getControllerNameForPod(pod, receivedAdmissionReview.Request.Namespace); controllerName != nil {
-			name = fmt.Sprintf("%s-%s", *controllerName, receivedAdmissionReview.Request.Namespace)
+			name = *controllerName
 		} else {
 			log.Info(ErrNoName)
 			return &admissionResponse


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Envoy and AppMesh need to reach consensus on the virtual node name to make things work. 

Envoy knows about virtual node name from injector. It’s either by naming convention (it is deploymentname-namespace today), or an annotation.

AppMesh knows about the virtual node names from CRDs (users need to create virtual node CRDs). 

As long as these two names match, things would work. 

The current naming convention, `controllerName-namespace`, was proposed to resolve potential name conflicts across name space. However, that also means customers need to complicate their virtual node name in the CRDs so that they can match with the injector naming convention. 

I think a good API should make defaults work best for the majority, and also provide overrides for the minorities. In this case, I would argue cross namespace naming conflict is the `minority` use case. And hence I propose changing the default naming convention to simplify controller name. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
