### PR TITLE
Add support for multiple meshes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,8 @@ notifications:
   email: false
 env:
   - GO111MODULE=on
-  - TEST_SUITE=goveralls
-  - TEST_SUITE=buildpushhash
-before_install:
-  - go get github.com/mattn/goveralls
 script: 
-  - make goveralls
+  - make test
   - make build
 after_success:
-  - test -n "$TRAVIS_TAG" && make build && make push 
+  - test -n "$TRAVIS_TAG" && make push

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.10.x
+go: 1.12.x
 sudo: true
 services:
 - docker
@@ -7,11 +7,13 @@ install: true
 notifications:
   email: false
 env:
+  - GO111MODULE=on
   - TEST_SUITE=goveralls
   - TEST_SUITE=buildpushhash
 before_install:
   - go get github.com/mattn/goveralls
 script: 
-  - "make $TEST_SUITE"
+  - make goveralls
+  - make build
 after_success:
   - test -n "$TRAVIS_TAG" && make build && make push 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ env:
   - GO111MODULE=on
 script: 
   - make test
-  - make build
+  - docker build -t aws-app-mesh-inject .
 after_success:
   - test -n "$TRAVIS_TAG" && make push

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ notifications:
 env:
   - GO111MODULE=on
 script: 
-  - make test
-  - docker build -t aws-app-mesh-inject .
+  - make ci-test-build
 after_success:
-  - test -n "$TRAVIS_TAG" && make push
+  - test -n "$TRAVIS_TAG" && make build && make push

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ buildhash: | hashtag build
 
 pushhash: | hashtag push
 
+ci-test-build:
+	go test ./...
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o appmeshinject ./cmd/app-mesh-inject/*.go
+
 #
 # Appmesh inject deployment
 #

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # App Mesh Inject
 
-The AWS App Mesh Kubernetes sidecar injecting Admission Controller.
+[![Build Status](https://travis-ci.org/aws/aws-app-mesh-inject.svg?branch=master)](https://travis-ci.org/aws/aws-app-mesh-inject)
 
+The AWS App Mesh Kubernetes sidecar injecting Admission Controller.
 
 ## Prerequisites
 * [openssl](https://www.openssl.org/source/)

--- a/README.md
+++ b/README.md
@@ -151,12 +151,15 @@ The name of the controller that creates the pod will be used as virtual node nam
 is created by a deployment, the virtual node name will be `<deployment name>-<namespace>`. 
 To override, add `appmesh.k8s.aws/virtualNode: <virtual node name>` annotation to the pod spec. 
 
+The mesh name provided at install time can be overridden with the `appmesh.k8s.aws/mesh: <mesh name>` annotation.
+
 For example:
 ```yaml
 kind: Deployment
 spec:
     metadata:
       annotations:
+        appmesh.k8s.aws/mesh: my-mesh
         appmesh.k8s.aws/ports: "8079,8080"
         appmesh.k8s.aws/virtualNode: my-app
         appmesh.k8s.aws/sidecarInjectorWebhook: disabled

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/aws-app-mesh-inject
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.18.4 // indirect
+	github.com/aws/aws-sdk-go v1.18.4
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -27,6 +27,7 @@ var (
 	ErrNoPorts                = errors.New("No ports specified for injection, doing nothing")
 	ErrNoName                 = errors.New("No VirtualNode name specified for injection, doing nothing")
 	ErrNoObject               = errors.New("No Object passed to mutate")
+	meshNameAnnotation        = "appmesh.k8s.aws/mesh"
 	portsAnnotation           = "appmesh.k8s.aws/ports"
 	virtualNodeNameAnnotation = "appmesh.k8s.aws/virtualNode"
 	sidecarInjectAnnotation   = "appmesh.k8s.aws/sidecarInjectorWebhook"
@@ -172,6 +173,12 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 		return &admissionResponse
 	}
 
+	// set mesh name
+	meshName := s.Config.MeshName
+	if v, ok := pod.ObjectMeta.Annotations[meshNameAnnotation]; ok {
+		meshName = v
+	}
+
 	// set ports
 	if v, ok := pod.ObjectMeta.Annotations[portsAnnotation]; ok {
 		ports = v
@@ -218,7 +225,7 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 			ContainerImage:  s.Config.SidecarImage,
 			LogLevel:        s.Config.LogLevel,
 			Region:          s.Config.Region,
-			MeshName:        s.Config.MeshName,
+			MeshName:        meshName,
 			MemoryRequests:  s.Config.SidecarMemory,
 			CpuRequests:     s.Config.SidecarCpu,
 		},


### PR DESCRIPTION
This PR introduces a new pod annotation `appmesh.k8s.aws/mesh` that allows overriding the default mesh name specified at install time. 

Fix: #16

PS. I've fixed the CI build but the ECR push needs to be addressed in another PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
