### PR TITLE
Defaulted Envoy log level to "info"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ ci-test-build:
 # Uses the image from developer account
 deploydev:
 	$(eval export IMAGE_NAME=${REPO}:${IMAGE_TAG})
-	$(eval export MESH_REGION)
 	$(eval export MESH_NAME)
 	./hack/deployInjector.sh
 
@@ -60,8 +59,6 @@ deploydevhash: | hashtag deploydev
 
 # Uses the official image from EKS account.
 deploy:
-	$(eval export IMAGE_NAME=602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-app-mesh-inject:v0.1.0)
-	$(eval export MESH_REGION)
 	$(eval export MESH_NAME)
 	./hack/deployInjector.sh
 

--- a/deploy/inject.yaml.template
+++ b/deploy/inject.yaml.template
@@ -61,19 +61,19 @@ spec:
       serviceAccountName: aws-app-mesh-inject-sa
       containers:
         - name: webhook
-          image: ${IMAGE_NAME}
+          image: ${IMAGE_NAME:-602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-app-mesh-inject:v0.1.0}
           env:
             - name: APPMESH_REGION
-              value: ${MESH_REGION}
+              value: ${MESH_REGION:-}
             - name: APPMESH_NAME
               value: ${MESH_NAME}
             - name: APPMESH_LOG_LEVEL
-              value: debug
+              value: ${ENVOY_LOG_LEVEL:-info}
           imagePullPolicy: Always
           command:
             - ./appmeshinject
-            - -sidecar-image=${SIDECAR_IMAGE}
-            - -init-image=${INIT_IMAGE}
+            - -sidecar-image=${SIDECAR_IMAGE:-111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.9.0.0-prod}
+            - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest}
             - -inject-xray-sidecar=${INJECT_XRAY_SIDECAR:-false}
             - -enable-stats-tags=${ENABLE_STATS_TAGS:-false}
           resources:

--- a/hack/deployInjector.sh
+++ b/hack/deployInjector.sh
@@ -3,7 +3,6 @@
 set -ue
 
 [ -z "$MESH_NAME" ] && { echo "Need to set the environment variable MESH_NAME"; exit 1; }
-[ -z "$IMAGE_NAME" ] && { echo "Need to set the environment variable IMAGE_NAME"; exit 1; }
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "Please install jq before continue"

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -34,17 +34,4 @@ curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/v0.1.0/hack/ca-bu
 
 chmod u+x ./hack/ca-bundle.sh ./hack/gen-cert.sh
 
-export IMAGE_NAME=602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-app-mesh-inject:v0.1.0
-export MESH_REGION=""
-
-# Change this to true if you want to inject xray-daemon as sidecar
-export INJECT_XRAY_SIDECAR="false"
-
-# Change this to true if you want to sidecar (envoy) to enable stats_tags
-# https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/stats.proto#config-metrics-v2-statsconfig
-export ENABLE_STATS_TAGS="false"
-
-export SIDECAR_IMAGE=111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.9.0.0-prod
-export INIT_IMAGE=111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest
-
 curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/v0.1.0/hack/deployInjector.sh | bash


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-app-mesh-inject/issues/33

*Description of changes:*
Defaulted Envoy log level to "info" to be aligned with the appmesh default. 
https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html
Assigned default values to all environment variables other than `MESH_NAME` and `CA_BUNDLE`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
