### PR TITLE
Removed the sanity check of IMAGE_NAME

### DIFF
--- a/hack/deployInjector.sh
+++ b/hack/deployInjector.sh
@@ -34,12 +34,4 @@ else
     exit 1
 fi
 
-ACTUAL_APPMESH_IMAGE=$(kubectl get deployment aws-app-mesh-inject -n appmesh-inject -o=jsonpath="{.spec.template.spec.containers[0].image}")
-if [[ "$ACTUAL_APPMESH_IMAGE" = "$IMAGE_NAME" ]]; then
-    echo "App Mesh image has been set up"
-else
-    echo "App Mesh image is unexpected. Expect:${IMAGE_NAME}, Actual:${ACTUAL_APPMESH_IMAGE}"
-    exit 1
-fi
-
 echo "The injector is ready"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since now users are able to use the default value of IMAGE_NAME, we can no longer check the image name value after injection. 

Removed this sanity check. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
