### PR TITLE
Set the proxy route manager to the latest stable version

### DIFF
--- a/cmd/app-mesh-inject/main.go
+++ b/cmd/app-mesh-inject/main.go
@@ -56,7 +56,7 @@ func init() {
 	flag.StringVar(&cfg.SidecarImage, "sidecar-image", "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.9.1.0-prod", "Envoy sidecar container image.")
 	flag.StringVar(&cfg.SidecarCpu, "sidecar-cpu-requests", "10m", "Envoy sidecar CPU resources requests.")
 	flag.StringVar(&cfg.SidecarMemory, "sidecar-memory-requests", "32Mi", "Envoy sidecar memory resources requests.")
-	flag.StringVar(&cfg.InitImage, "init-image", "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest", "Init container image.")
+	flag.StringVar(&cfg.InitImage, "init-image", "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2", "Init container image.")
 	flag.StringVar(&cfg.IgnoredIPs, "ignored-ips", "169.254.169.254", "Init container ignored IPs.")
 	flag.BoolVar(&cfg.InjectXraySidecar, "inject-xray-sidecar", false, "Enable Envoy X-Ray tracing integration and injects xray-daemon as sidecar")
 	flag.BoolVar(&cfg.EnableStatsTags, "enable-stats-tags", false, "Enable Envoy to tag stats")

--- a/deploy/inject.yaml.template
+++ b/deploy/inject.yaml.template
@@ -73,7 +73,7 @@ spec:
           command:
             - ./appmeshinject
             - -sidecar-image=${SIDECAR_IMAGE:-111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.9.1.0-prod}
-            - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest}
+            - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2}
             - -inject-xray-sidecar=${INJECT_XRAY_SIDECAR:-false}
             - -enable-stats-tags=${ENABLE_STATS_TAGS:-false}
           resources:

--- a/pkg/patch/init_test.go
+++ b/pkg/patch/init_test.go
@@ -8,7 +8,7 @@ import (
 func Test_Init(t *testing.T) {
 	meta := InitMeta{
 		Ports:          "80,443",
-		ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest",
+		ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
 		IgnoredIPs:     "169.254.169.254",
 	}
 

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -13,7 +13,7 @@ func TestGeneratePatch_AppendSidecarFalse(t *testing.T) {
 		AppendInit:            false,
 		Init: InitMeta{
 			Ports:          "80,443",
-			ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest",
+			ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
 			IgnoredIPs:     "169.254.169.254",
 		},
 		Sidecar: SidecarMeta{
@@ -45,7 +45,7 @@ func TestGeneratePatch_AppendSidecarTrue(t *testing.T) {
 		AppendInit:            false,
 		Init: InitMeta{
 			Ports:          "80,443",
-			ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest",
+			ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
 			IgnoredIPs:     "169.254.169.254",
 		},
 		Sidecar: SidecarMeta{
@@ -70,7 +70,7 @@ func TestGeneratePatch_AppendSidecarTrue(t *testing.T) {
 }
 
 func verifyPatch(t *testing.T, patch string, meta Meta) {
-	if !strings.Contains(patch, "aws-appmesh-proxy-route-manager:latest") {
+	if !strings.Contains(patch, "aws-appmesh-proxy-route-manager:v2") {
 		t.Errorf("Init container image not found")
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-app-mesh-roadmap/issues/62
https://github.com/aws/aws-app-mesh-inject/issues/41

*Description of changes:*

* Fixes a bug in proxy route manager where custom `APPMESH_EGRESS_IGNORED_PORTS` were ignored by the script.
* We've started versioning the container with this release. This version is simply `v2`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
