### PR TITLE
Remove --no-cache from docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ goveralls:
 #
 .PHONY: build push hashtag buildpushhash buildhash pushhash
 build:
-	docker build --no-cache -t ${REPO}:${IMAGE_TAG} .
+	docker build -t ${REPO}:${IMAGE_TAG} .
 
 push:
 	$(eval export IMAGE_ACCOUNT)


### PR DESCRIPTION
*Description of changes:*
Enable build caching to speed up docker builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
