### PR TITLE
Fix ENABLE_STATSD default value

### DIFF
--- a/deploy/inject.yaml.template
+++ b/deploy/inject.yaml.template
@@ -76,7 +76,7 @@ spec:
             - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2}
             - -inject-xray-sidecar=${INJECT_XRAY_SIDECAR:-false}
             - -enable-stats-tags=${ENABLE_STATS_TAGS:-false}
-            - -enable-statsd=${ENABLE_STATSD:-""}
+            - -enable-statsd=${ENABLE_STATSD:-false}
             - -inject-statsd-exporter-sidecar=${INJECT_STATSD_EXPORTER_SIDECAR:-false}
           resources:
             limits:


### PR DESCRIPTION
*Issue #, if available:*

When installing the injector using

```
curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/scripts/install.sh | bash
```

The pod fails to start with the following message:

```
invalid boolean value "" for -enable-statsd: parse error
```

*Description of changes:*

This sets the default value to `false` similarly to how it's done with ENABLE_STATS_TAGS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
