### PR TITLE
Fetch CA bundle from requestheader-client-ca-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ export INJECT_XRAY_SIDECAR=true
 The CA bundle can also be configured manually by setting a `CA_BUNDLE` environment variable to the content of the bundle.
 
 ```
-$ export CA_BUNDLE=$(cat /path/to/ca-bundle)
+$ export CA_BUNDLE=$(cat /path/to/ca-bundle | base64)
 ```
 
 Now you can deploy the appmesh injector
@@ -122,4 +122,4 @@ If the CA bundle isn't configured properly, the pod will log the following log m
 TLS handshake error from 10.0.0.1:45390: remote error: tls: bad certificate
 ```
 
-If this happens, set the `CA_BUNDLE` environment variable to the content of the CA bundle (it should start with `-----BEGIN CERTIFICATE-----`)
+If this happens, set the `CA_BUNDLE` environment variable to the content of the CA bundle. Make sure that this value is base64 encoded (e.g. it shouldn't start with `-----BEGIN CERTIFICATE-----`).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ $ export INJECT_STATSD_EXPORTER_SIDECAR=true
 $ export INJECT_XRAY_SIDECAR=true
 ```
 
+(Optional) The appmesh injector needs a CA bundle to trust the webhooks coming from Kubernetes. The installation scripts will make a best-effort attempt at fetching it automatically, but this cannot be done in some cases.
+The CA bundle can also be configured manually by setting a `CA_BUNDLE` environment variable to the content of the bundle.
+
+```
+$ export CA_BUNDLE=$(cat /path/to/ca-bundle)
+```
 
 Now you can deploy the appmesh injector
 
@@ -105,3 +111,15 @@ spec:
 ```
 
 To see an example on how to use this sidecar injector you can visit the [demo page](https://github.com/aws/aws-app-mesh-examples/tree/master/examples/interactive-demo).
+
+## Troubleshooting
+
+### CA bundle not configured properly
+
+If the CA bundle isn't configured properly, the pod will log the following log message:
+
+```
+TLS handshake error from 10.0.0.1:45390: remote error: tls: bad certificate
+```
+
+If this happens, set the `CA_BUNDLE` environment variable to the content of the CA bundle (it should start with `-----BEGIN CERTIFICATE-----`)

--- a/scripts/ca-bundle.sh
+++ b/scripts/ca-bundle.sh
@@ -5,10 +5,8 @@ set -o pipefail
 
 ROOT=$(cd $(dirname $0)/../; pwd)
 
-export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
-
 if [[ -z $CA_BUNDLE ]]; then
-    export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.requestheader-client-ca-file}' | base64 | tr -d '\n')
+    export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
 fi
 
 if [[ -z $CA_BUNDLE ]]; then

--- a/scripts/ca-bundle.sh
+++ b/scripts/ca-bundle.sh
@@ -8,6 +8,10 @@ ROOT=$(cd $(dirname $0)/../; pwd)
 export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
 
 if [[ -z $CA_BUNDLE ]]; then
+    export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.requestheader-client-ca-file}' | base64 | tr -d '\n')
+fi
+
+if [[ -z $CA_BUNDLE ]]; then
     export CA_BUNDLE=$(kubectl config view --raw -o json --minify | jq -r '.clusters[0].cluster."certificate-authority-data"' | tr -d '"')
 fi
 


### PR DESCRIPTION
*Description of changes:*
The installation scripts looks for the CA bundle in the `extension-apiserver-authentication.client-ca-file` configmap.
This is not configured on EKS, but `requestheader-client-ca-file` is and looks correct on my cluster.

This changes the install script to look for that value if not found in `client-ca-file`.
Please note that I am not sure whether this is a reliable way to fetch the CA bundle, it works for me but YMMV.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
