### PR TITLE
Add an option to pass list of ignored ports in egress traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ $ export MESH_NAME=my_mesh_name
 $ export ENABLE_STATS_TAGS=true
 ```
 
-(Optional) If enabled, Envoy will emit DogStatsD metrics to 127.0.0.1:8125, where it expects to find a statsd receiver. This could be either a Datadog sidecar, or something like [statsd_exporter](https://github.com/prometheus/statsd_exporter) (see below). 
+(Optional) If enabled, Envoy will emit DogStatsD metrics to 127.0.0.1:8125, where it expects to find a statsd receiver. This could be either a Datadog sidecar, or something like [statsd_exporter](https://github.com/prometheus/statsd_exporter) (see below).
 ```
 $ export ENABLE_STATSD=true
 ```
 
-(Optional) To deploy [statsd_exporter](https://github.com/prometheus/statsd_exporter) as a sidecar, which can recieve statsd metrics and republish them in Prometheus format. It listens for metrics on 127.0.0.1:8125, and exposes a prometheus endpoint at 127.0.0.1:9201. This is useful as statsd provides metrics around request latency (p50, p99 etc), whereas the standard Envoy prometheus endpoint does not. 
+(Optional) To deploy [statsd_exporter](https://github.com/prometheus/statsd_exporter) as a sidecar, which can recieve statsd metrics and republish them in Prometheus format. It listens for metrics on 127.0.0.1:8125, and exposes a prometheus endpoint at 127.0.0.1:9201. This is useful as statsd provides metrics around request latency (p50, p99 etc), whereas the standard Envoy prometheus endpoint does not.
 ```
 $ export INJECT_STATSD_EXPORTER_SIDECAR=true
 ```
@@ -86,6 +86,9 @@ to particular pods in that namespace, add `appmesh.k8s.aws/sidecarInjectorWebhoo
 All container ports defined in the pod spec will be passed to sidecars as application ports.
 To override, add `appmesh.k8s.aws/ports: "<ports>"` annotation to the pod spec.
 
+By default all egress traffic ports will be routed, except SSH.
+To override, add `appmesh.k8s.aws/egressIgnoredPorts: "<ports>"` annotation to the pod spec. ( Comma separated list of ports for which egress traffic will be ignored )
+
 The name of the controller that creates the pod will be used as virtual node name and pass over to the sidecar. For example, if a pod
 is created by a deployment, the virtual node name will be `<deployment name>-<namespace>`.
 To override, add `appmesh.k8s.aws/virtualNode: <virtual node name>` annotation to the pod spec.
@@ -100,6 +103,7 @@ spec:
       annotations:
         appmesh.k8s.aws/mesh: my-mesh
         appmesh.k8s.aws/ports: "8079,8080"
+        appmesh.k8s.aws/egressIgnoredPorts: "22"
         appmesh.k8s.aws/virtualNode: my-app
         appmesh.k8s.aws/sidecarInjectorWebhook: disabled
 ```

--- a/README.md
+++ b/README.md
@@ -93,12 +93,17 @@ The name of the controller that creates the pod will be used as virtual node nam
 is created by a deployment, the virtual node name will be `<deployment name>-<namespace>`.
 To override, add `appmesh.k8s.aws/virtualNode: <virtual node name>` annotation to the pod spec.
 
-The mesh name provided at install time can be overridden with the `appmesh.k8s.aws/mesh: <mesh name>` annotation.
+The mesh name provided at install time can be overridden with the `appmesh.k8s.aws/mesh: <mesh name>` annotation at POD spec level.
 
 For example:
 ```yaml
+apiVersion: appsv1
 kind: Deployment
+metadata:
+  labels:
+    name: my-cool-deployment
 spec:
+  template:
     metadata:
       annotations:
         appmesh.k8s.aws/mesh: my-mesh

--- a/pkg/patch/init.go
+++ b/pkg/patch/init.go
@@ -41,15 +41,20 @@ const initContainerTemplate = `
     {
       "name": "APPMESH_EGRESS_IGNORED_IP",
       "value": "{{ .IgnoredIPs }}"
+    },
+    {
+      "name": "APPMESH_EGRESS_IGNORED_PORTS",
+      "value": "{{ .EgressIgnoredPorts }}"
     }
   ]
 }
 `
 
 type InitMeta struct {
-	ContainerImage string
-	Ports          string
-	IgnoredIPs     string
+	ContainerImage     string
+	Ports              string
+	EgressIgnoredPorts string
+	IgnoredIPs         string
 }
 
 func renderInit(meta InitMeta) (string, error) {

--- a/pkg/patch/init_test.go
+++ b/pkg/patch/init_test.go
@@ -7,9 +7,10 @@ import (
 
 func Test_Init(t *testing.T) {
 	meta := InitMeta{
-		Ports:          "80,443",
-		ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
-		IgnoredIPs:     "169.254.169.254",
+		Ports:              "80,443",
+		EgressIgnoredPorts: "22",
+		ContainerImage:     "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
+		IgnoredIPs:         "169.254.169.254",
 	}
 
 	init, err := renderInit(meta)

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -12,9 +12,10 @@ func TestGeneratePatch_AppendSidecarFalse(t *testing.T) {
 		AppendSidecar:         false,
 		AppendInit:            false,
 		Init: InitMeta{
-			Ports:          "80,443",
-			ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
-			IgnoredIPs:     "169.254.169.254",
+			Ports:              "80,443",
+			EgressIgnoredPorts: "22",
+			ContainerImage:     "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
+			IgnoredIPs:         "169.254.169.254",
 		},
 		Sidecar: SidecarMeta{
 			MeshName:          "global",
@@ -44,9 +45,10 @@ func TestGeneratePatch_AppendSidecarTrue(t *testing.T) {
 		AppendSidecar:         true,
 		AppendInit:            false,
 		Init: InitMeta{
-			Ports:          "80,443",
-			ContainerImage: "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
-			IgnoredIPs:     "169.254.169.254",
+			Ports:              "80,443",
+			EgressIgnoredPorts: "22",
+			ContainerImage:     "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
+			IgnoredIPs:         "169.254.169.254",
 		},
 		Sidecar: SidecarMeta{
 			MeshName:          "global",

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -2,6 +2,11 @@ package webhook
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
 	"github.com/aws/aws-app-mesh-inject/pkg/config"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -9,10 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/fake"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
 )
 
 const admissionReview = `
@@ -50,6 +51,7 @@ const admissionReview = `
         },
         "annotations": {
           "appmesh.k8s.aws/ports": "9898",
+          "appmesh.k8s.aws/egress_ignored_ports": "22",
           "appmesh.k8s.aws/virtualNode": "podinfo"
         }
       },


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-app-mesh-roadmap/issues/62
By default all egress traffic is going to flow through Envoy/AppMesh.
We don't want database traffic to be flowing through it.
Workaround currently is to not use `app-mesh-inject` and manually add sidecar pod and init pod.

*Description of changes:*
Implement `appmesh.k8s.aws/egressIgnoredPorts` annotation to have an option of providing list of ports to be ignored in egress traffic flow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
