### PR TITLE
Changing branch reference to master

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,13 +25,13 @@ echo "\nWorking directory at ${tmpdir}\n"
 cd $tmpdir
 
 mkdir -p deploy
-curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/v0.1.5/deploy/inject-ns.yaml > deploy/inject-ns.yaml
-curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/v0.1.5/deploy/inject.yaml.template > deploy/inject.yaml.template
+curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/deploy/inject-ns.yaml > deploy/inject-ns.yaml
+curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/deploy/inject.yaml.template > deploy/inject.yaml.template
 
 mkdir -p scripts
-curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/v0.1.5/scripts/gen-cert.sh > scripts/gen-cert.sh
-curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/v0.1.5/scripts/ca-bundle.sh > scripts/ca-bundle.sh
+curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/scripts/gen-cert.sh > scripts/gen-cert.sh
+curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/scripts/ca-bundle.sh > scripts/ca-bundle.sh
 
 chmod u+x ./scripts/ca-bundle.sh ./scripts/gen-cert.sh
 
-curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/v0.1.5/scripts/deployInjector.sh | bash
+curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/scripts/deployInjector.sh | bash


### PR DESCRIPTION
https://github.com/aws/aws-app-mesh-inject/issues/63#issuecomment-513880258

Removing versioned branch references, replacing with master.  @CarmenAPuccio has verified compatibility with 1.13.  Please let me know if there are other reasons for needing to hardcode to v0.1.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
