### PR TITLE
Read cpu and memory from annotations

### DIFF
--- a/deploy/inject.yaml.template
+++ b/deploy/inject.yaml.template
@@ -78,6 +78,8 @@ spec:
             - -enable-stats-tags=${ENABLE_STATS_TAGS:-false}
             - -enable-statsd=${ENABLE_STATSD:-false}
             - -inject-statsd-exporter-sidecar=${INJECT_STATSD_EXPORTER_SIDECAR:-false}
+            - -sidecar-cpu-requests=${SIDECAR_CPU_REQUESTS:-100m}
+            - -sidecar-memory-requests=${SIDECAR_MEMORY_REQUESTS:-128Mi}
           resources:
             limits:
               memory: 500Mi

--- a/pkg/patch/sidecar.go
+++ b/pkg/patch/sidecar.go
@@ -10,7 +10,6 @@ const envoyContainerTemplate = `
 {
   "name": "envoy",
   "image": "{{ .ContainerImage }}",
-  "imagePullPolicy": "Always",
   "securityContext": {
     "runAsUser": 1337
   },

--- a/pkg/patch/sidecar.go
+++ b/pkg/patch/sidecar.go
@@ -10,6 +10,7 @@ const envoyContainerTemplate = `
 {
   "name": "envoy",
   "image": "{{ .ContainerImage }}",
+  "imagePullPolicy": "Always",
   "securityContext": {
     "runAsUser": 1337
   },

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -31,6 +31,8 @@ var (
 	meshNameAnnotation           = "appmesh.k8s.aws/mesh"
 	portsAnnotation              = "appmesh.k8s.aws/ports"
 	egressIgnoredPortsAnnotation = "appmesh.k8s.aws/egressIgnoredPorts"
+	cpuRequestAnnotation         = "appmesh.k8s.aws/cpuRequest"
+	memoryRequestAnnotation      = "appmesh.k8s.aws/memoryRequest"
 	virtualNodeNameAnnotation    = "appmesh.k8s.aws/virtualNode"
 	sidecarInjectAnnotation      = "appmesh.k8s.aws/sidecarInjectorWebhook"
 )
@@ -217,6 +219,22 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 		}
 	}
 
+	// set cpu-request
+	var cpuRequest string
+	if v, ok := pod.ObjectMeta.Annotations[cpuRequestAnnotation]; ok {
+		cpuRequest = v
+	} else {
+		cpuRequest = s.Config.SidecarCpu
+	}
+
+	// set memory-request
+	var memoryRequest string
+	if v, ok := pod.ObjectMeta.Annotations[memoryRequestAnnotation]; ok {
+		memoryRequest = v
+	} else {
+		memoryRequest = s.Config.SidecarMemory
+	}
+
 	klog.Infof("Patching pod %v", pod.ObjectMeta)
 
 	// patch pod spec
@@ -237,8 +255,8 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 			LogLevel:                    s.Config.LogLevel,
 			Region:                      s.Config.Region,
 			MeshName:                    meshName,
-			MemoryRequests:              s.Config.SidecarMemory,
-			CpuRequests:                 s.Config.SidecarCpu,
+			MemoryRequests:              memoryRequest,
+			CpuRequests:                 cpuRequest,
 			InjectXraySidecar:           s.Config.InjectXraySidecar,
 			EnableStatsTags:             s.Config.EnableStatsTags,
 			EnableStatsD:                s.Config.EnableStatsD,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Provide a way to override the default CPU and Memory requests for Envoy container.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
