### PR TITLE
Update default Envoy image to v1.11.1.1-prod

### DIFF
--- a/cmd/app-mesh-inject/main.go
+++ b/cmd/app-mesh-inject/main.go
@@ -53,7 +53,7 @@ func init() {
 	flag.StringVar(&cfg.TlsCert, "tlscert", "/etc/webhook/certs/cert.pem", "Location of TLS Cert file.")
 	flag.StringVar(&cfg.TlsKey, "tlskey", "/etc/webhook/certs/key.pem", "Location of TLS key file.")
 	flag.BoolVar(&enableTLS, "enable-tls", true, "Enable TLS.")
-	flag.StringVar(&cfg.SidecarImage, "sidecar-image", "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.11.1.0-prod", "Envoy sidecar container image.")
+	flag.StringVar(&cfg.SidecarImage, "sidecar-image", "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.11.1.1-prod", "Envoy sidecar container image.")
 	flag.StringVar(&cfg.SidecarCpu, "sidecar-cpu-requests", "10m", "Envoy sidecar CPU resources requests.")
 	flag.StringVar(&cfg.SidecarMemory, "sidecar-memory-requests", "32Mi", "Envoy sidecar memory resources requests.")
 	flag.StringVar(&cfg.InitImage, "init-image", "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2", "Init container image.")


### PR DESCRIPTION
*Issue #, if available:* aws/aws-app-mesh-roadmap#99

*Description of changes:*
Updating the default image to the latest version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
