### PR TITLE
Add default value for injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ kubectl label namespace appmesh-demo appmesh.k8s.aws/sidecarInjectorWebhook=enab
 
 ### Default behavior and how to override
 
-By default, sidecars will be injected to all new pods in the namespace that has enabled sidecar injector webhook. To disable injecting the sidecar
-to particular pods in that namespace, add `appmesh.k8s.aws/sidecarInjectorWebhook: disabled` annotation to the pod spec.
-If the injector is run with `-inject-default=false`, sidecars will only be injected to pods that have the `appmesh.k8s.aws/sidecarInjectorWebhook: enabled` annotation.
+For namespaces with sidecar injection enabled, pods will be injected if the `appmesh.k8s.aws/sidecarInjectorWebhook` annotation is `enabled` and will not be injected if it is `disabled`.
+For pods with no annotation, they will be injected if the `-inject-default=true` flag is passed (the default for this flag) and will not be injected if the `-inject-default=false` flag is passed.
 
 All container ports defined in the pod spec will be passed to sidecars as application ports.
 To override, add `appmesh.k8s.aws/ports: "<ports>"` annotation to the pod spec.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ kubectl label namespace appmesh-demo appmesh.k8s.aws/sidecarInjectorWebhook=enab
 
 ### Default behavior and how to override
 
-Sidecars will be injected to all new pods in the namespace that has enabled sidecar injector webhook. To disable injecting the sidecar
+By default, sidecars will be injected to all new pods in the namespace that has enabled sidecar injector webhook. To disable injecting the sidecar
 to particular pods in that namespace, add `appmesh.k8s.aws/sidecarInjectorWebhook: disabled` annotation to the pod spec.
+If the injector is run with `-inject-default=false`, sidecars will only be injected to pods that have the `appmesh.k8s.aws/sidecarInjectorWebhook: enabled` annotation.
 
 All container ports defined in the pod spec will be passed to sidecars as application ports.
 To override, add `appmesh.k8s.aws/ports: "<ports>"` annotation to the pod spec.

--- a/cmd/app-mesh-inject/main.go
+++ b/cmd/app-mesh-inject/main.go
@@ -69,6 +69,7 @@ func init() {
 	flag.BoolVar(&cfg.EnableStatsTags, "enable-stats-tags", false, "Enable Envoy to tag stats")
 	flag.BoolVar(&cfg.EnableStatsD, "enable-statsd", false, "If enabled, Envoy will send DogStatsD metrics to 127.0.0.1:8125")
 	flag.BoolVar(&cfg.InjectStatsDExporterSidecar, "inject-statsd-exporter-sidecar", false, "This flag is deprecated and does nothing")
+	flag.BoolVar(&cfg.InjectDefault, "inject-default", true, "If enabled, sidecars will be injected in the absence of the corresponding pod annotation")
 }
 
 func main() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,9 @@ type Config struct {
 	TlsCert string
 	TlsKey  string
 
+	// Injetion Settings
+	InjectDefault bool
+
 	// Sidecar settings
 	SidecarImage  string
 	SidecarCpu    string

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -172,10 +172,13 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 		return admissionResponseError(err)
 	}
 
-	// If sidecar injection is disabled in the annotation, we skip mutating
-	switch strings.ToLower(pod.ObjectMeta.Annotations[sidecarInjectAnnotation]) {
-	case "disabled":
-		klog.Info("Sidecar inject is disabled. Skipping mutating")
+	shouldInject, err := s.shouldInject(pod)
+	if err != nil {
+		return admissionResponseError(err)
+	}
+
+	if shouldInject == false {
+		klog.Info("Sidecar inject is disabled. Skipping mutation")
 		return &admissionResponse
 	}
 
@@ -298,6 +301,30 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 	admissionResponse.PatchType = &pt
 
 	return &admissionResponse
+}
+
+// Determines if the sidecars should be injected or not
+func (s *Server) shouldInject(pod corev1.Pod) (bool, error) {
+	// If sidecar injection is explicitely set in the annotation, honor it
+	sidecarInjection := strings.ToLower(pod.ObjectMeta.Annotations[sidecarInjectAnnotation])
+	if sidecarInjection != "" {
+		inject := s.convertAnnotation(sidecarInjection)
+		klog.Info(fmt.Sprintf("Sidecar inject is %v in %v for pod %v/%v", inject, sidecarInjectAnnotation, pod.GetNamespace(), pod.GetName()))
+		return inject, nil
+	}
+
+	// Otherwise use the default value
+	return s.Config.InjectDefault, nil
+}
+
+// Converts the injection annotation string to a boolean
+func (s *Server) convertAnnotation(annotation string) bool {
+	switch strings.ToLower(annotation) {
+	case "disabled":
+		return false
+	default:
+		return true
+	}
 }
 
 func (s *Server) decode(b []byte, o runtime.Object) error {

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -159,7 +159,7 @@ const admissionReviewTemplate = `
           "appmesh.k8s.aws/ports": "9898",
           "appmesh.k8s.aws/egress_ignored_ports": "22",
           "appmesh.k8s.aws/virtualNode": "podinfo",
-          "appmesh.k8s.aws/sidecarInjectorWebhook": "%v
+          "appmesh.k8s.aws/sidecarInjectorWebhook": "%v"
         }
       },
       "spec": {
@@ -343,8 +343,8 @@ func TestServer_Inject_OptIn_WithInvalidAnnotation(t *testing.T) {
 	rr := sendWebhook(t, optInServerConfig, getAdmissionReviewPayload("invalid"))
 
 	rrBody := rr.Body.String()
-	if !containsPatch(rrBody) {
-		t.Errorf(fmt.Sprintf("expected handler to patch payload (got %v)", rrBody))
+	if containsPatch(rrBody) {
+		t.Errorf(fmt.Sprintf("expected handler to not patch payload (got %v)", rrBody))
 	}
 }
 
@@ -379,8 +379,8 @@ func TestServer_Inject_OptOut_WithInvalidAnnotation(t *testing.T) {
 	rr := sendWebhook(t, defaultServerConfig, getAdmissionReviewPayload("invalid"))
 
 	rrBody := rr.Body.String()
-	if containsPatch(rrBody) {
-		t.Errorf(fmt.Sprintf("expected handler to not patch payload (got %v)", rrBody))
+	if !containsPatch(rrBody) {
+		t.Errorf(fmt.Sprintf("expected handler to patch payload (got %v)", rrBody))
 	}
 }
 

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -121,14 +122,129 @@ const admissionReview = `
 }
 `
 
-func mockServer() *Server {
-	cfg := config.Config{
-		Port:     8080,
-		MeshName: "global",
-		Region:   "us-west-2",
-		LogLevel: "debug",
-	}
+const admissionReviewTemplate = `
+{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "53ad2101-497a-11e9-960e-0edb66a862f2",
+    "kind": {
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
+    },
+    "resource": {
+      "group": "",
+      "version": "v1",
+      "resource": "pods"
+    },
+    "namespace": "test",
+    "operation": "CREATE",
+    "userInfo": {
+      "username": "system:unsecured",
+      "groups": [
+        "system:masters",
+        "system:authenticated"
+      ]
+    },
+    "object": {
+      "metadata": {
+        "generateName": "podinfo-7c45b75c87-",
+        "creationTimestamp": null,
+        "labels": {
+          "app": "podinfo",
+          "pod-template-hash": "3701631743"
+        },
+        "annotations": {
+          "appmesh.k8s.aws/ports": "9898",
+          "appmesh.k8s.aws/egress_ignored_ports": "22",
+          "appmesh.k8s.aws/virtualNode": "podinfo",
+          "appmesh.k8s.aws/sidecarInjectorWebhook": "%v"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-xhfkr",
+            "secret": {
+              "secretName": "default-token-xhfkr"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "podinfod",
+            "image": "quay.io/stefanprodan/podinfo:1.4.0",
+            "command": [
+              "./podinfo",
+              "--port=9898"
+            ],
+            "ports": [
+              {
+                "name": "http",
+                "containerPort": 9898,
+                "protocol": "TCP"
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "default-token-xhfkr",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {}
+    },
+    "oldObject": null
+  }
+}
+`
 
+var defaultServerConfig = config.Config{
+	Port:     8080,
+	MeshName: "global",
+	Region:   "us-west-2",
+	LogLevel: "debug",
+	InjectDefault: true,
+}
+
+var optInServerConfig = config.Config{
+	Port:          8080,
+	MeshName:      "global",
+	Region:        "us-west-2",
+	LogLevel:      "debug",
+	InjectDefault: false,
+}
+
+func mockServerWithConfig(cfg config.Config) *Server {
 	scheme := runtime.NewScheme()
 	corev1.AddToScheme(scheme)
 	admissionregistrationv1beta1.AddToScheme(scheme)
@@ -153,10 +269,14 @@ func mockServer() *Server {
 	}
 }
 
-func TestServer_Inject(t *testing.T) {
-	srv := mockServer()
+func mockServer() *Server {
+	return mockServerWithConfig(defaultServerConfig)
+}
 
-	req, err := http.NewRequest("POST", "/", bytes.NewBuffer([]byte(admissionReview)))
+func sendWebhook(t *testing.T, cfg config.Config, admissionPayload string) *httptest.ResponseRecorder {
+	srv := mockServerWithConfig(cfg)
+
+	req, err := http.NewRequest("POST", "/", bytes.NewBuffer([]byte(admissionPayload)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,8 +293,76 @@ func TestServer_Inject(t *testing.T) {
 			status, http.StatusOK)
 	}
 
+	return rr
+}
+
+func getAdmissionReviewPayload(sidecarInjectorWebhookEnabled string) string {
+	return fmt.Sprintf(admissionReviewTemplate, sidecarInjectorWebhookEnabled)
+}
+
+func containsPatch(rrBody string) bool {
+	return strings.Contains(rrBody, "\"patchType\":\"JSONPatch\"")
+}
+
+func TestServer_Inject(t *testing.T) {
+	rr := sendWebhook(t, defaultServerConfig, admissionReview)
+
 	if !strings.Contains(rr.Body.String(), "\"allowed\":true") {
 		t.Errorf("handler returned wrong result")
+	}
+}
+
+func TestServer_Inject_OptIn_WithoutAnnotation(t *testing.T) {
+	rr := sendWebhook(t, optInServerConfig, admissionReview)
+
+	rrBody := rr.Body.String()
+	if containsPatch(rrBody) {
+		t.Errorf(fmt.Sprintf("expected handler to not patch payload (got %v)", rrBody))
+	}
+}
+
+func TestServer_Inject_OptIn_WithDisabledAnnotation(t *testing.T) {
+	rr := sendWebhook(t, optInServerConfig, getAdmissionReviewPayload("disabled"))
+
+	rrBody := rr.Body.String()
+	if containsPatch(rrBody) {
+		t.Errorf(fmt.Sprintf("expected handler to not patch payload (got %v)", rrBody))
+	}
+}
+
+func TestServer_Inject_OptIn_WithEnabledAnnotation(t *testing.T) {
+	rr := sendWebhook(t, optInServerConfig, getAdmissionReviewPayload("enabled"))
+
+	rrBody := rr.Body.String()
+	if !containsPatch(rrBody) {
+		t.Errorf(fmt.Sprintf("expected handler to patch payload (got %v)", rrBody))
+	}
+}
+
+func TestServer_Inject_OptOut_WithoutAnnotation(t *testing.T) {
+	rr := sendWebhook(t, defaultServerConfig, admissionReview)
+
+	rrBody := rr.Body.String()
+	if !containsPatch(rrBody) {
+		t.Errorf(fmt.Sprintf("expected handler to patch payload (got %v)", rrBody))
+	}
+}
+
+func TestServer_Inject_OptOut_WithEnabledAnnotation(t *testing.T) {
+	rr := sendWebhook(t, defaultServerConfig, getAdmissionReviewPayload("enabled"))
+
+	rrBody := rr.Body.String()
+	if !containsPatch(rrBody) {
+		t.Errorf(fmt.Sprintf("expected handler to patch payload (got %v)", rrBody))
+	}
+}
+
+func TestServer_Inject_OptOut_WithDisabledAnnotation(t *testing.T) {
+	rr := sendWebhook(t, defaultServerConfig, getAdmissionReviewPayload("disabled"))
+
+	rrBody := rr.Body.String()
+	if containsPatch(rrBody) {
+		t.Errorf(fmt.Sprintf("expected handler to not patch payload (got %v)", rrBody))
 	}
 }
 


### PR DESCRIPTION
Adds a new parameter on the injector command to define whether or not the sidecars should be injected by default.

If set to `true` (default), the behaviour will be the same as the current one (sidecars are injected unless the pod has the `appmesh.k8s.aws/sidecarInjectorWebhook` annotation set to `disabled`)

If set to `false`, sidecars will only be injected if the  `appmesh.k8s.aws/sidecarInjectorWebhook` annotation on the pod is `enabled`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
