### PR TITLE
Add preview channel option

### DIFF
--- a/cmd/app-mesh-inject/main.go
+++ b/cmd/app-mesh-inject/main.go
@@ -47,6 +47,7 @@ func init() {
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&cfg.MeshName, "mesh-name", os.Getenv("APPMESH_NAME"), "AWS App Mesh name")
 	flag.StringVar(&cfg.Region, "region", os.Getenv("APPMESH_REGION"), "AWS App Mesh region")
+	flag.BoolVar(&cfg.Preview, "preview", false, "Enable preview channel")
 	flag.StringVar(&cfg.LogLevel, "log-level", os.Getenv("APPMESH_LOG_LEVEL"), "AWS App Mesh envoy log level")
 	flag.BoolVar(&cfg.EcrSecret, "ecr-secret", false, "Inject AWS app mesh pull secrets")
 	flag.IntVar(&cfg.Port, "port", 8080, "Webhook port")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	SidecarMemory string
 	MeshName      string
 	Region        string
+	Preview       bool
 	LogLevel      string
 	EcrSecret     bool
 

--- a/pkg/patch/sidecar.go
+++ b/pkg/patch/sidecar.go
@@ -26,6 +26,10 @@ const envoyContainerTemplate = `
       "value": "mesh/{{ .MeshName }}/virtualNode/{{ .VirtualNodeName }}"
     },
     {
+      "name": "APPMESH_PREVIEW",
+      "value": "{{ .Preview }}"
+    },
+    {
       "name": "ENVOY_LOG_LEVEL",
       "value": "{{ .LogLevel }}"
     },
@@ -119,6 +123,7 @@ type SidecarMeta struct {
 	ContainerImage              string
 	MeshName                    string
 	VirtualNodeName             string
+	Preview                     string
 	LogLevel                    string
 	Region                      string
 	CpuRequests                 string

--- a/pkg/patch/sidecar_test.go
+++ b/pkg/patch/sidecar_test.go
@@ -10,6 +10,7 @@ func Test_Sidecar(t *testing.T) {
 	meta := SidecarMeta{
 		LogLevel:        "debug",
 		Region:          "us-west-2",
+		Preview:         "0",
 		VirtualNodeName: "podinfo",
 		MeshName:        "global",
 		ContainerImage:  "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:latest",
@@ -23,6 +24,7 @@ func Test_Sidecar_WithXray(t *testing.T) {
 	meta := SidecarMeta{
 		LogLevel:          "debug",
 		Region:            "us-west-2",
+		Preview:           "0",
 		VirtualNodeName:   "podinfo",
 		MeshName:          "global",
 		ContainerImage:    "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:latest",
@@ -38,6 +40,7 @@ func Test_Sidecar_WithStatsTags(t *testing.T) {
 	meta := SidecarMeta{
 		LogLevel:        "debug",
 		Region:          "us-west-2",
+		Preview:         "0",
 		VirtualNodeName: "podinfo",
 		MeshName:        "global",
 		ContainerImage:  "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:latest",
@@ -54,6 +57,7 @@ func Test_Sidecar_WithStatsD(t *testing.T) {
 	meta := SidecarMeta{
 		LogLevel:                    "debug",
 		Region:                      "us-west-2",
+		Preview:                     "0",
 		VirtualNodeName:             "podinfo",
 		MeshName:                    "global",
 		ContainerImage:              "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:latest",
@@ -101,6 +105,7 @@ func checkEnvoy(t *testing.T, m map[string]interface{}, meta SidecarMeta) {
 		"APPMESH_VIRTUAL_NODE_NAME": fmt.Sprintf("mesh/%s/virtualNode/%s", meta.MeshName, meta.VirtualNodeName),
 		"AWS_REGION":                meta.Region,
 		"ENVOY_LOG_LEVEL":           meta.LogLevel,
+		"APPMESH_PREVIEW":           meta.Preview,
 	}
 
 	if meta.InjectXraySidecar {

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -35,6 +35,7 @@ var (
 	memoryRequestAnnotation      = "appmesh.k8s.aws/memoryRequest"
 	virtualNodeNameAnnotation    = "appmesh.k8s.aws/virtualNode"
 	sidecarInjectAnnotation      = "appmesh.k8s.aws/sidecarInjectorWebhook"
+	previewAnnotation            = "appmesh.k8s.aws/preview"
 )
 
 type Server struct {
@@ -219,6 +220,22 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 		}
 	}
 
+	// set preview channel enabled
+	var preview string
+	if v, ok := pod.ObjectMeta.Annotations[previewAnnotation]; ok {
+		if v == "true" {
+			preview = "1"
+		} else {
+			preview = "0"
+		}
+	} else {
+		if s.Config.Preview {
+			preview = "1"
+		} else {
+			preview = "0"
+		}
+	}
+
 	// set cpu-request
 	var cpuRequest string
 	if v, ok := pod.ObjectMeta.Annotations[cpuRequestAnnotation]; ok {
@@ -254,6 +271,7 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 			ContainerImage:              s.Config.SidecarImage,
 			LogLevel:                    s.Config.LogLevel,
 			Region:                      s.Config.Region,
+			Preview:                     preview,
 			MeshName:                    meshName,
 			MemoryRequests:              memoryRequest,
 			CpuRequests:                 cpuRequest,


### PR DESCRIPTION
*Issue #, if available:* #78 

*Description of changes:*

Add options to enable preview channel signing for the Envoy container.

Tested with a deployment like:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  namespace: appmesh-preview-test
spec:
  replicas: 1
  template:
    metadata:
      annotations:
        appmesh.k8s.aws/mesh: test-mesh
        appmesh.k8s.aws/virtualNode: test-node
        appmesh.k8s.aws/preview: "true"
```

Note that preview channel resources cannot yet be created through the CRDs. Resources can still be created through the CLI and used within k8s. https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/75 has been created for CRD support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
