### PR TITLE
Support selection of region for installing using CLI

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,6 +137,15 @@ $ make clean
 ```
 
 ### Option 2: download and execute the install script
+
+Specify the region to download sidecar injector. 
+Please reference the [AWS Regional Table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) for the supported regions
+
+```
+$ export AWS_REGION='us-east-1'
+```
+Download and execute the install script
+
 ```bash
 curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/scripts/install.sh | bash
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -142,7 +142,7 @@ Specify the region to download sidecar injector.
 Please reference the [AWS Regional Table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) for the supported regions
 
 ```
-$ export AWS_REGION='us-east-1'
+$ export MESH_REGION='us-east-1'
 ```
 Download and execute the install script
 

--- a/deploy/inject.yaml.template
+++ b/deploy/inject.yaml.template
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: aws-app-mesh-inject-sa
       containers:
         - name: webhook
-          image: ${IMAGE_NAME:-602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-app-mesh-inject:${VERSION}}
+          image: ${IMAGE_NAME:-602401143452.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-app-mesh-inject:${VERSION}}
           env:
             - name: APPMESH_REGION
               value: ${MESH_REGION:-}
@@ -72,8 +72,8 @@ spec:
           imagePullPolicy: Always
           command:
             - ./appmeshinject
-            - -sidecar-image=${SIDECAR_IMAGE:-840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.11.2.0-prod}
-            - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2}
+            - -sidecar-image=${SIDECAR_IMAGE:-840364872350.dkr.ecr.${AWS_REGION}.amazonaws.com/aws-appmesh-envoy:v1.11.2.0-prod}
+            - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.${AWS_REGION}.amazonaws.com/aws-appmesh-proxy-route-manager:v2}
             - -inject-xray-sidecar=${INJECT_XRAY_SIDECAR:-false}
             - -enable-stats-tags=${ENABLE_STATS_TAGS:-false}
             - -enable-statsd=${ENABLE_STATSD:-false}

--- a/deploy/inject.yaml.template
+++ b/deploy/inject.yaml.template
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: aws-app-mesh-inject-sa
       containers:
         - name: webhook
-          image: ${IMAGE_NAME:-602401143452.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-app-mesh-inject:${VERSION}}
+          image: ${IMAGE_NAME:-602401143452.dkr.ecr.${MESH_REGION}.amazonaws.com/amazon/aws-app-mesh-inject:${VERSION}}
           env:
             - name: APPMESH_REGION
               value: ${MESH_REGION:-}
@@ -72,8 +72,8 @@ spec:
           imagePullPolicy: Always
           command:
             - ./appmeshinject
-            - -sidecar-image=${SIDECAR_IMAGE:-840364872350.dkr.ecr.${AWS_REGION}.amazonaws.com/aws-appmesh-envoy:v1.11.2.0-prod}
-            - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.${AWS_REGION}.amazonaws.com/aws-appmesh-proxy-route-manager:v2}
+            - -sidecar-image=${SIDECAR_IMAGE:-840364872350.dkr.ecr.${MESH_REGION}.amazonaws.com/aws-appmesh-envoy:v1.11.2.0-prod}
+            - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.${MESH_REGION}.amazonaws.com/aws-appmesh-proxy-route-manager:v2}
             - -inject-xray-sidecar=${INJECT_XRAY_SIDECAR:-false}
             - -enable-stats-tags=${ENABLE_STATS_TAGS:-false}
             - -enable-statsd=${ENABLE_STATSD:-false}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,13 +13,13 @@
 
 REPO=${REPO:-aws/aws-app-mesh-inject}
 BRANCH=${BRANCH:-master}
-export AWS_REGION=${AWS_REGION:-us-west-2}
+export MESH_REGION=${MESH_REGION:-us-west-2}
 export VERSION=${VERSION:-v0.2.0}
 
 set -e
 set -o pipefail
 
-echo "Using AWS region ${AWS_REGION}"
+echo "Using AWS region ${MESH_REGION}"
 echo "Fetching ${VERSION} from https://github.com/${REPO}/tree/${BRANCH}"
 
 [ -z "$MESH_NAME" ] && { echo "Need to set the environment variable MESH_NAME"; exit 1; }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,13 +10,16 @@
 # so the version should be updated with each release.
 #
 
+
 REPO=${REPO:-aws/aws-app-mesh-inject}
 BRANCH=${BRANCH:-master}
+export AWS_REGION=${AWS_REGION:-us-west-2}
 export VERSION=${VERSION:-v0.2.0}
 
 set -e
 set -o pipefail
 
+echo "Using AWS region ${AWS_REGION}"
 echo "Fetching ${VERSION} from https://github.com/${REPO}/tree/${BRANCH}"
 
 [ -z "$MESH_NAME" ] && { echo "Need to set the environment variable MESH_NAME"; exit 1; }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated the installation guide with CLI, to allow to select regions for downloading the sidecar injector.

If the region is not specified, 'us-west-2' will be used as default.


Files modified:  
INSTALL.md
scripts/install.sh
deploy/inject.yaml.template


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
