### PR TITLE
Rename Envoy tracing config volume

### DIFF
--- a/pkg/patch/datadog.go
+++ b/pkg/patch/datadog.go
@@ -119,5 +119,5 @@ func renderDatadogInitContainer(address string, port string) (string, error) {
 
 // shared volume between the init container and Envoy
 func renderDatadogConfigVolume() string {
-	return configVolume
+	return tracingConfigVolume
 }

--- a/pkg/patch/jaeger.go
+++ b/pkg/patch/jaeger.go
@@ -62,9 +62,9 @@ const injectJaegerTemplate = `
 }
 `
 
-const configVolume = `
+const tracingConfigVolume = `
 {
-  "name": "config",
+  "name": "envoy-tracing-config",
   "emptyDir": {}
 }
 `
@@ -145,5 +145,5 @@ func escapeYaml(yaml string) (string, error) {
 
 // shared volume between the init container and Envoy
 func renderJaegerConfigVolume() string {
-	return configVolume
+	return tracingConfigVolume
 }

--- a/pkg/patch/sidecar.go
+++ b/pkg/patch/sidecar.go
@@ -57,7 +57,7 @@ const envoyContainerTemplate = `
   "volumeMounts": [
     {
       "mountPath": "/tmp/envoy",
-      "name": "config"
+      "name": "envoy-tracing-config"
     }
   ]{{ end }},
   "resources": {
@@ -92,23 +92,23 @@ const xrayDaemonContainerTemplate = `
 `
 
 type SidecarMeta struct {
-	ContainerImage              string
-	MeshName                    string
-	VirtualNodeName             string
-	Preview                     string
-	LogLevel                    string
-	Region                      string
-	CpuRequests                 string
-	MemoryRequests              string
-	EnableJaegerTracing         bool
-	JaegerAddress               string
-	JaegerPort                  string
-	EnableDatadogTracing        bool
-	DatadogAddress              string
-	DatadogPort                 string
-	InjectXraySidecar           bool
-	EnableStatsTags             bool
-	EnableStatsD                bool
+	ContainerImage       string
+	MeshName             string
+	VirtualNodeName      string
+	Preview              string
+	LogLevel             string
+	Region               string
+	CpuRequests          string
+	MemoryRequests       string
+	EnableJaegerTracing  bool
+	JaegerAddress        string
+	JaegerPort           string
+	EnableDatadogTracing bool
+	DatadogAddress       string
+	DatadogPort          string
+	InjectXraySidecar    bool
+	EnableStatsTags      bool
+	EnableStatsD         bool
 }
 
 func renderSidecars(meta SidecarMeta) ([]string, error) {

--- a/pkg/patch/sidecar_test.go
+++ b/pkg/patch/sidecar_test.go
@@ -150,7 +150,7 @@ func checkEnvoy(t *testing.T, m map[string]interface{}, meta SidecarMeta) {
 
 		mount := mounts[0].(map[string]interface{})
 		mountName := mount["name"].(string)
-		expectedMountName := "config"
+		expectedMountName := "envoy-tracing-config"
 		if mountName != expectedMountName {
 			t.Errorf("volume mount name is set to %s instead of %s", mountName, expectedMountName)
 		}


### PR DESCRIPTION
Rename config volume to `envoy-tracing-config` fixes #96

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
