### PR TITLE
Rename config dir to envoy-tracing-config

### DIFF
--- a/pkg/patch/jaeger.go
+++ b/pkg/patch/jaeger.go
@@ -46,7 +46,7 @@ const injectJaegerTemplate = `
   "volumeMounts": [
   	{
       "mountPath": "/tmp/envoy",
-      "name": "config"
+      "name": "envoy-tracing-config"
     }
   ],
   "resources": {


### PR DESCRIPTION
Fixes incorrect config volume mount reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
