### PR TITLE
Support for Amazon EKS on AWS Fargate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _output
 .vscode
 *.swp
+coverage.out

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -1,6 +1,8 @@
 package config
 
 const (
+	//Pod Annotations
+
 	//AppMeshCNIAnnotation specifies that CNI will be used to configure traffic interception
 	AppMeshCNIAnnotation = "appmesh.k8s.aws/appmeshCNI"
 	//AppMeshCpuRequestAnnotation specifies the CPU requests for proxy
@@ -29,6 +31,11 @@ const (
 	AppMeshSidecarInjectAnnotation = "appmesh.k8s.aws/sidecarInjectorWebhook"
 	//AppMeshVirtualNodeNameAnnotation specifies the App Mesh VirtualNode used by proxy
 	AppMeshVirtualNodeNameAnnotation = "appmesh.k8s.aws/virtualNode"
+
+	//Pod Labels
+
+	//FargateProfileLabel is added by fargate-scheduler when pod is running on AWS Fargate
+	FargateProfileLabel = "eks.amazonaws.com/fargate-profile"
 
 	// Fixed proxy container configuration required by App Mesh
 

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-app-mesh-inject/pkg/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGeneratePatch_AppendSidecarFalse(t *testing.T) {
@@ -78,6 +81,49 @@ func TestGeneratePatch_AppendSidecarTrue(t *testing.T) {
 	verifyPatch(t, string(patch), meta)
 }
 
+func TestGeneratePatch_AppendSidecarTrue_WithFargateProfile(t *testing.T) {
+	meta := Meta{
+		AppendImagePullSecret: false,
+		HasImagePullSecret:    false,
+		AppendSidecar:         true,
+		AppendInit:            false,
+		Init: InitMeta{
+			Ports:              "80,443",
+			EgressIgnoredPorts: "22",
+			ContainerImage:     "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
+			IgnoredIPs:         "169.254.169.254",
+		},
+		Sidecar: SidecarMeta{
+			MeshName:          "global",
+			VirtualNodeName:   "podinfo",
+			Region:            "us-west-2",
+			LogLevel:          "debug",
+			ContainerImage:    "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:latest",
+			CpuRequests:       "10m",
+			MemoryRequests:    "32Mi",
+			InjectXraySidecar: true,
+			EnableStatsTags:   true,
+		},
+		PodMetadata: metav1.ObjectMeta{
+			Labels: map[string]string{
+				config.FargateProfileLabel: "some-profile",
+			},
+		},
+	}
+
+	patch, err := GeneratePatch(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !json.Valid([]byte(patch)) {
+		t.Fatal("invalid json")
+	}
+
+	verifyAppMeshCNIPatch(t, string(patch))
+	verifyPatch(t, string(patch), meta)
+}
+
 func TestGeneratePatch_AppendSidecarTrue_WithAppMeshCNI(t *testing.T) {
 	meta := Meta{
 		AppendImagePullSecret: false,
@@ -101,8 +147,10 @@ func TestGeneratePatch_AppendSidecarTrue_WithAppMeshCNI(t *testing.T) {
 			InjectXraySidecar: true,
 			EnableStatsTags:   true,
 		},
-		PodAnnotations: map[string]string{
-			"appmesh.k8s.aws/appmeshCNI": "enabled",
+		PodMetadata: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"appmesh.k8s.aws/appmeshCNI": "enabled",
+			},
 		},
 	}
 
@@ -115,7 +163,7 @@ func TestGeneratePatch_AppendSidecarTrue_WithAppMeshCNI(t *testing.T) {
 		t.Fatal("invalid json")
 	}
 
-	verifyAppMeshCNIAnnotationsPatch(t, string(patch))
+	verifyAppMeshCNIPatch(t, string(patch))
 	verifyPatch(t, string(patch), meta)
 }
 
@@ -125,7 +173,7 @@ func verifyInitContainerPatch(t *testing.T, patch string) {
 	}
 }
 
-func verifyAppMeshCNIAnnotationsPatch(t *testing.T, patch string) {
+func verifyAppMeshCNIPatch(t *testing.T, patch string) {
 	if strings.Contains(patch, "aws-appmesh-proxy-route-manager:v2") {
 		t.Errorf("Init container is added when appmeshCNI is enabled")
 	}

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -251,7 +251,7 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 
 	// patch pod spec
 	podPatch, err := patch.GeneratePatch(patch.Meta{
-		PodAnnotations:        pod.ObjectMeta.Annotations,
+		PodMetadata:           pod.ObjectMeta,
 		HasImagePullSecret:    s.Config.EcrSecret,
 		AppendImagePullSecret: len(pod.Spec.ImagePullSecrets) > 0,
 		AppendInit:            len(pod.Spec.InitContainers) > 0,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use fargate-profile label to determine if appmeshCNI is enabled or not. https://aws.amazon.com/blogs/aws/amazon-eks-on-aws-fargate-now-generally-available/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
