### PR TITLE
Revert "Update Envoy image to v1.12.2.0-prod"

### DIFF
--- a/cmd/app-mesh-inject/main.go
+++ b/cmd/app-mesh-inject/main.go
@@ -54,7 +54,7 @@ func init() {
 	flag.StringVar(&cfg.TlsCert, "tlscert", "/etc/webhook/certs/cert.pem", "Location of TLS Cert file.")
 	flag.StringVar(&cfg.TlsKey, "tlskey", "/etc/webhook/certs/key.pem", "Location of TLS key file.")
 	flag.BoolVar(&enableTLS, "enable-tls", true, "Enable TLS.")
-	flag.StringVar(&cfg.SidecarImage, "sidecar-image", "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.2.0-prod", "Envoy sidecar container image.")
+	flag.StringVar(&cfg.SidecarImage, "sidecar-image", "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.1.1-prod", "Envoy sidecar container image.")
 	flag.StringVar(&cfg.SidecarCpu, "sidecar-cpu-requests", "10m", "Envoy sidecar CPU resources requests.")
 	flag.StringVar(&cfg.SidecarMemory, "sidecar-memory-requests", "32Mi", "Envoy sidecar memory resources requests.")
 	flag.StringVar(&cfg.InitImage, "init-image", "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2", "Init container image.")

--- a/deploy/inject.yaml.template
+++ b/deploy/inject.yaml.template
@@ -72,7 +72,7 @@ spec:
           imagePullPolicy: Always
           command:
             - ./appmeshinject
-            - -sidecar-image=${SIDECAR_IMAGE:-840364872350.dkr.ecr.${MESH_REGION}.amazonaws.com/aws-appmesh-envoy:v1.12.2.0-prod}
+            - -sidecar-image=${SIDECAR_IMAGE:-840364872350.dkr.ecr.${MESH_REGION}.amazonaws.com/aws-appmesh-envoy:v1.12.1.1-prod}
             - -init-image=${INIT_IMAGE:-111345817488.dkr.ecr.${MESH_REGION}.amazonaws.com/aws-appmesh-proxy-route-manager:v2}
             - -inject-xray-sidecar=${INJECT_XRAY_SIDECAR:-false}
             - -enable-stats-tags=${ENABLE_STATS_TAGS:-false}

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: Always
           command:
             - ./appmeshinject
-            - -sidecar-image=840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.2.0-prod
+            - -sidecar-image=840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.1.1-prod
             - -init-image=111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2
             - -inject-xray-sidecar=false
             - -enable-stats-tags=false


### PR DESCRIPTION
This reverts commit f0184a0233f53bf76b55112889dbb13565ad4bfc.

*Issue #, if available:* https://github.com/aws/aws-app-mesh-roadmap/issues/144

*Description of changes:*
Need to roll back Envoy image due to a reported crash in v1.12.2.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
