### PR TITLE
Copy attribution doc to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk add git
 RUN mkdir -p /go/src/github.com/aws/aws-app-mesh-inject
 WORKDIR /go/src/github.com/aws/aws-app-mesh-inject
 
+ENV GOPRIVATE *
+
 COPY go.mod .
 COPY go.sum .
 
@@ -18,6 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' \
 
 FROM scratch
 COPY --from=build-env /go/src/github.com/aws/aws-app-mesh-inject/appmeshinject .
+COPY --from=build-env /go/src/github.com/aws/aws-app-mesh-inject/ATTRIBUTION.txt /ATTRIBUTION.txt
 COPY --from=build-env /etc/passwd /etc/passwd
 USER webhook
 ENTRYPOINT ["/appmeshinject"]


### PR DESCRIPTION
*Description of changes:*
* Add open source attribution document to container image (guarantees licenses are present in thing people actually download). 
* Also set GOPRIVATE to *, which is necessary for amazon employees.  Hopefully this doesn't affect non-amazon contributors, we can revisit if it does.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
