### PR TITLE
add `enable-iam-for-service-accounts` to automatically patch fsGroup

### DIFF
--- a/cmd/app-mesh-inject/main.go
+++ b/cmd/app-mesh-inject/main.go
@@ -70,6 +70,7 @@ func init() {
 	flag.BoolVar(&cfg.EnableStatsD, "enable-statsd", false, "If enabled, Envoy will send DogStatsD metrics to 127.0.0.1:8125")
 	flag.BoolVar(&cfg.InjectStatsDExporterSidecar, "inject-statsd-exporter-sidecar", false, "This flag is deprecated and does nothing")
 	flag.BoolVar(&cfg.InjectDefault, "inject-default", true, "If enabled, sidecars will be injected in the absence of the corresponding pod annotation")
+	flag.BoolVar(&cfg.EnableIAMForServiceAccounts, "enable-iam-for-service-accounts", true, "If enabled, an fsGroup: 1337 will be injected in the absence of it within pod securityContext")
 }
 
 func main() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,10 @@ type Config struct {
 	// Injetion Settings
 	InjectDefault bool
 
+	// If enabled, an fsGroup: 1337 will be injected in the absence of it within pod securityContext
+	// see https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8 for more details
+	EnableIAMForServiceAccounts bool
+
 	// Sidecar settings
 	SidecarImage  string
 	SidecarCpu    string

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -16,6 +16,11 @@ const (
 	createAnnotation = `{"op":"add","path":"/metadata/annotations","value":{"%s": "%s"}}`
 	updateAnnotation = `{"op":"%s","path":"/metadata/annotations/%s","value":"%s"}`
 
+	// We don't want to make this configurable since users shouldn't rely on this
+	// feature to set a fsGroup for them. This feature is just to protect innocent 
+	// users that are not aware of the limitation of iam-for-service-accounts:
+	// https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8
+	// Users should set fsGroup on the pod spec directly if a specific fsGroup is desired.
 	defaultFSGroup int64 = 1337
 )
 

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -2,6 +2,7 @@ package patch
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -258,5 +259,31 @@ func verifyPatch(t *testing.T, patch string, meta Meta) {
 		if strings.Contains(patch, "amazon/aws-xray-daemon") {
 			t.Errorf("X-Ray container found when InjectXraySidecar=false")
 		}
+	}
+}
+
+func Test_podFSGroupPatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		fsGroup int64
+		want    string
+	}{
+		{
+			name:    "fs_group 1337",
+			fsGroup: 1337,
+			want:    `{"op":"add","path":"/spec/securityContext/fsGroup", "value": 1337}`,
+		},
+		{
+			name:    "fs_group 1338",
+			fsGroup: 1338,
+			want:    `{"op":"add","path":"/spec/securityContext/fsGroup", "value": 1338}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := podFSGroupPatch(tt.fsGroup); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("fsGroupPatches() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -256,6 +256,7 @@ func (s *Server) mutate(receivedAdmissionReview v1beta1.AdmissionReview) *v1beta
 		AppendImagePullSecret: len(pod.Spec.ImagePullSecrets) > 0,
 		AppendInit:            len(pod.Spec.InitContainers) > 0,
 		AppendSidecar:         len(pod.Spec.Containers) > 0,
+		InjectFSGroup:         s.Config.EnableIAMForServiceAccounts && (pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil),
 		Init: patch.InitMeta{
 			Ports:              ports,
 			EgressIgnoredPorts: egressIgnoredPorts,


### PR DESCRIPTION
Automatically inject an fsGroup:1337 when there is no fsGroup settings. (default enabled and can be disabled by `--enable-iam-for-service-accounts=false`

This is to bypass current limitation for [iam-for-pods](https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8) to benefit most users using iam-for-pods :D 

Test done:
1. without `--enable-iam-for-service-accounts=false`
    * pod with 
      ```
      securityContext:
        runAsNonRoot: false
      ```
      got injected to be
      ```
      securityContext:
        runAsNonRoot: false
        fsGroup: 1337
      ```
    * pod with 
      ```
      securityContext:
        fsGroup: 1338
      ```
      remain unchanged
    * pod with no securityContext
      got injected to be
      ```
      securityContext:
        fsGroup: 1337
      ```
1. with `--enable-iam-for-service-accounts=false`, nothing changes :D 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
