### PR TITLE
Fixing name of the emptyDir created for the envoy config

### DIFF
--- a/pkg/patch/datadog.go
+++ b/pkg/patch/datadog.go
@@ -44,7 +44,7 @@ const injectDatadogTemplate = `
   "volumeMounts": [
   	{
       "mountPath": "/tmp/envoy",
-      "name": "config"
+      "name": "envoy-tracing-config"
     }
   ],
   "resources": {


### PR DESCRIPTION
*Issue*

I was able to verify that the helm chart option to enable the Datadog tracer works well (for 0.2.0)
But [this commit](https://github.com/aws/aws-app-mesh-inject/commit/58b37690dd1556b83204a6284404bce858ce63dc) is missing out on one modification.
Using 0.3.0 or 0.4.0 of the injector will not work if the Datadog tracer is enabled (the Volume and the VolumeMount have different names, so the pod never starts if is mutated by the injector).

*Description of changes:*

@stefanprodan - Apologies for the very long delay in testing the [helm change](https://github.com/aws/eks-charts#datadog-tracing), and thank you very much for doing it a few months back.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
