### PR TITLE
Adding 'inject-secret-mounts' to automatically mount files to proxy

### DIFF
--- a/kustomize/cluster-roles.yaml
+++ b/kustomize/cluster-roles.yaml
@@ -11,7 +11,7 @@ metadata:
   name: appmesh-inject
 rules:
   - apiGroups: ["*"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "secrets"]
     verbs: ["get"]
 ---
 kind: ClusterRoleBinding

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -31,6 +31,8 @@ const (
 	AppMeshSidecarInjectAnnotation = "appmesh.k8s.aws/sidecarInjectorWebhook"
 	//AppMeshVirtualNodeNameAnnotation specifies the App Mesh VirtualNode used by proxy
 	AppMeshVirtualNodeNameAnnotation = "appmesh.k8s.aws/virtualNode"
+	//AppMeshSecretMountsAnnotation specifies the list of Secret that need to be mounted to the proxy as a volume
+	AppMeshSecretMountsAnnotation = "appmesh.k8s.aws/secretMounts"
 
 	//Pod Labels
 

--- a/pkg/patch/secret.go
+++ b/pkg/patch/secret.go
@@ -1,0 +1,53 @@
+package patch
+
+import (
+	"bufio"
+	"bytes"
+	"text/template"
+)
+
+const secretVolumeMount = `
+{
+  "mountPath": "{{ .MountPath }}",
+  "name": "{{ .SecretName }}",
+  "readOnly": true
+}
+`
+
+const secretVolume = `
+{
+  "name": "{{ .SecretName }}",
+  "secret":
+  {
+    "secretName": "{{ .SecretName }}"
+  }
+}
+`
+
+func renderSecretVolumeMount(secretMount SecretMount) (string, error) {
+	return renderSecretCommon(secretMount, secretVolumeMount)
+}
+
+
+func renderSecretVolume(secretMount SecretMount) (string, error) {
+	return renderSecretCommon(secretMount, secretVolume)
+}
+
+func renderSecretCommon(secretMount SecretMount, tpl string) (string, error) {
+	tmpl, err := template.New("mount").Parse(tpl)
+	if err != nil {
+		return "", err
+	}
+
+	var data bytes.Buffer
+	writer := bufio.NewWriter(&data)
+	if err := tmpl.Execute(writer, secretMount); err != nil {
+		return "", err
+	}
+	err = writer.Flush()
+	if err != nil {
+		return "", err
+	}
+
+	return data.String(), nil
+}

--- a/pkg/patch/sidecar.go
+++ b/pkg/patch/sidecar.go
@@ -97,6 +97,11 @@ const xrayDaemonContainerTemplate = `
 }
 `
 
+type SecretMount struct {
+	SecretName string
+	MountPath  string
+}
+
 type SidecarMeta struct {
 	ContainerImage       string
 	MeshName             string
@@ -115,6 +120,7 @@ type SidecarMeta struct {
 	InjectXraySidecar    bool
 	EnableStatsTags      bool
 	EnableStatsD         bool
+	SecretMounts         []SecretMount
 }
 
 func renderSidecars(meta SidecarMeta) ([]string, error) {


### PR DESCRIPTION
Support operator to add an annotation like [1] to the pod,
appmesh injector will inject all secret files to the pod volumes and
mounts the data of each one to special path in the envoy proxy.

For example, pre-create both secret resources [0] and add the annotation
to the pod [1], appmesh injector will inject three files to /certs path
in the envoy container like [2].

In TLS configuring case, this feature gives an easy way to allow operator
to provide certs and key files to envoy, without this operator either has
to build an own envoy docker image with additional files or add the own
script to download these file from a middle service, e.g. AWS Secrets Manager,
or even both. The example shown this inconvenient pattern at [3].

Fixes aws#126

```
[0]
  apiVersion: v1
  kind: Secret
  metadata:
    name: svc1-cert-chain-key
  stringData:
    svc1_cert_chain.pem: |
      -----CERTIFICATE-----
      -----CA CERTIFICATE-----
    svc1_key.pem: |
      -----RSA ETAVIRP YEK-----
  ---
  apiVersion: v1
  kind: Secret
  metadata:
    name: svc1-svc2-ca-bundle
  stringData:
    svc1_svc2_ca_bundle.pem: |
      -----CA CERTIFICATE-----
      -----CA CERTIFICATE-----

[1]
  annotations:
    appmesh.k8s.aws/secretMounts: "svc1-cert-chain-key:/certs/svc1, svc1-svc2-ca-bundle:/certs"

[2]
  /
  └── certs
      ├── svc1
      │   ├── svc1_cert_chain.pem
      │   └── svc1_key.pem
      └── svc1_svc2_ca_bundle.pem

[3] https://github.com/aws/aws-app-mesh-examples/blob/master/walkthroughs/howto-tls-file-provided/src/customEnvoyImage/entryPoint.sh#L5
```