### PR TITLE
Update deprecated api for 1.16

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,6 +61,9 @@ metadata:
   name: appmesh-inject
   namespace: appmesh-system
 spec:
+  selector:
+    matchLabels:
+      name: appmesh-inject
   template:
     spec:
       containers:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ patches:
 mymesh.yaml
 ```yaml
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: appmesh-inject

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The mesh name provided at install time can be overridden with the `appmesh.k8s.a
 
 For example:
 ```yaml
-apiVersion: appsv1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ metadata:
   labels:
     name: my-cool-deployment
 spec:
+  selector:
+    matchLabels:
+      name: appmesh-inject
   template:
     metadata:
       annotations:

--- a/deploy/inject.yaml.template
+++ b/deploy/inject.yaml.template
@@ -43,7 +43,7 @@ spec:
   selector:
     name: appmesh-inject
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: appmesh-inject
@@ -52,6 +52,9 @@ metadata:
     name: appmesh-inject
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: appmesh-inject
   template:
     metadata:
       name: appmesh-inject

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: appmesh-inject
@@ -8,6 +8,9 @@ metadata:
     name: appmesh-inject
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: appmesh-inject
   template:
     metadata:
       name: appmesh-inject


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws/aws-app-mesh-inject/issues/132

*Description of changes:*
- In kubernetes v1.16, apps/v1veta Deployment API is deprecated, so I changed it to apps/v1.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
